### PR TITLE
Remove Unused JSON Check

### DIFF
--- a/i18n/config.py
+++ b/i18n/config.py
@@ -32,7 +32,7 @@ FILENAME_VARS = dict.fromkeys(
 
 settings = {
     'filename_format': '{namespace}.{locale}.{format}',
-    'file_format': 'yml' if yaml_available else 'json' if json_available else 'py',
+    'file_format': 'yml' if yaml_available else 'json',
     'available_locales': ['en'],
     'load_path': load_path,
     'locale': 'en',

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -9,12 +9,6 @@ try:
 except ImportError:
     yaml_available = False
 
-try:
-    __import__("json")
-    json_available = True
-except ImportError:
-    json_available = False
-
 # try to get existing path object
 # in case if config is being reloaded
 try:

--- a/i18n/loaders/__init__.py
+++ b/i18n/loaders/__init__.py
@@ -4,9 +4,8 @@ from .loader import Loader
 from ..errors import I18nFileLoadError
 from .python_loader import PythonLoader
 from .. import config
-if config.json_available:
-    from .json_loader import JsonLoader
-    __all__ += ("JsonLoader",)
+from .json_loader import JsonLoader
+__all__ += ("JsonLoader",)
 if config.yaml_available:
     from .yaml_loader import YamlLoader
     __all__ += ("YamlLoader",)

--- a/i18n/loaders/__init__.py
+++ b/i18n/loaders/__init__.py
@@ -1,11 +1,10 @@
-__all__: tuple = ("Loader", "PythonLoader", "I18nFileLoadError")
+__all__: tuple = ("Loader", "PythonLoader", "I18nFileLoadError", "JsonLoader")
 
 from .loader import Loader
 from ..errors import I18nFileLoadError
 from .python_loader import PythonLoader
 from .. import config
 from .json_loader import JsonLoader
-__all__ += ("JsonLoader",)
 if config.yaml_available:
     from .yaml_loader import YamlLoader
     __all__ += ("YamlLoader",)

--- a/i18n/resource_loader.py
+++ b/i18n/resource_loader.py
@@ -52,8 +52,7 @@ def init_loaders():
     init_python_loader()
     if config.yaml_available:
         init_yaml_loader()
-    if config.json_available:
-        init_json_loader()
+    init_json_loader()
 
 
 def init_python_loader():

--- a/i18n/tests/loader_tests.py
+++ b/i18n/tests/loader_tests.py
@@ -15,7 +15,7 @@ from i18n import resource_loader
 from i18n.errors import I18nFileLoadError, I18nInvalidFormat, I18nLockedError
 from i18n.translator import t
 from i18n import config
-from i18n.config import json_available, yaml_available
+from i18n.config import yaml_available
 from i18n import translator, translations, formatters
 from i18n.loaders import Loader
 
@@ -67,7 +67,6 @@ class TestFileLoader(unittest.TestCase):
         with self.assertRaisesRegex(I18nFileLoadError, "error loading file .*"):
             resource_loader.load_resource("foo.yml", "bar")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_load_wrong_json_file(self):
         resource_loader.init_json_loader()
         with self.assertRaisesRegex(I18nFileLoadError, "error getting data .*"):
@@ -119,7 +118,6 @@ class TestFileLoader(unittest.TestCase):
                 "foo",
             )
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_load_json_file(self):
         resource_loader.init_json_loader()
         data = resource_loader.load_resource(
@@ -172,7 +170,6 @@ en = {{"key": "value"}}
             finally:
                 os.chdir(orig_wd)
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_load_everything(self):
         i18n.load_path[0] = os.path.join(RESOURCE_FOLDER, "translations", "bar")
         config.set("file_format", "json")
@@ -197,7 +194,6 @@ en = {{"key": "value"}}
         with self.assertRaises(I18nFileLoadError):
             i18n.load_everything()
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_reload_everything(self):
         config.set("skip_locale_root_data", True)
         config.set("file_format", "json")
@@ -217,7 +213,6 @@ en = {{"key": "value"}}
             i18n.reload_everything()
             self.assertEqual(t("test.a"), "c")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_load_everything_lock(self):
         i18n.load_path[0] = os.path.join(RESOURCE_FOLDER, "translations", "bar")
         config.set("file_format", "json")
@@ -245,7 +240,6 @@ en = {{"key": "value"}}
 
         i18n.unload_everything()
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_use_locale_dirs(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -272,7 +266,6 @@ en = {{"key": "value"}}
         self.assertEqual(t("multilingual.hi"), "Hello")
         self.assertEqual(t("multilingual.hi", locale="uk"), "Привіт")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_load_file_with_strange_encoding(self):
         resource_loader.init_json_loader()
         config.set("encoding", "euc-jp")
@@ -415,7 +408,6 @@ en = {{"key": "value"}}
         resource_loader.search_translation("foo.normal_key", config.get("locale"))
         self.assertTrue(translations.has("foo.normal_key"))
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_json(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -423,7 +415,6 @@ en = {{"key": "value"}}
         resource_loader.search_translation("bar.baz.qux", config.get("locale"))
         self.assertTrue(translations.has("bar.baz.qux"))
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_without_ns(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -431,7 +422,6 @@ en = {{"key": "value"}}
         resource_loader.search_translation("foo", config.get("locale"))
         self.assertTrue(translations.has("foo"))
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_path_as_ns(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -440,7 +430,6 @@ en = {{"key": "value"}}
         resource_loader.search_translation("translations.foo", config.get("locale"))
         self.assertTrue(translations.has("translations.foo"))
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_without_ns_nested_dict__two_levels_neting__default_locale(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -452,7 +441,6 @@ en = {{"key": "value"}}
         self.assertTrue(translations.has("COMMON.VERSION"))
         self.assertEqual(translations.get("COMMON.VERSION"), "version")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_without_ns_nested_dict__two_levels_neting__other_locale(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -464,7 +452,6 @@ en = {{"key": "value"}}
         self.assertTrue(translations.has("COMMON.VERSION", locale="pl"))
         self.assertEqual(translations.get("COMMON.VERSION", locale="pl"), "wersja")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_without_ns_nested_dict__default_locale(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -476,7 +463,6 @@ en = {{"key": "value"}}
         self.assertTrue(translations.has("TOP_MENU.TOP_BAR.LOGS"))
         self.assertEqual(translations.get("TOP_MENU.TOP_BAR.LOGS"), "Logs")
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_search_translation_without_ns_nested_dict__other_locale(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")
@@ -501,7 +487,6 @@ en = {{"key": "value"}}
         reload(config)
         self.assertIs(i18n.load_path, config.get("load_path"))
 
-    @unittest.skipUnless(json_available, "json library not available")
     def test_static_references(self):
         resource_loader.init_json_loader()
         config.set("file_format", "json")

--- a/i18n/tests/run_tests.py
+++ b/i18n/tests/run_tests.py
@@ -77,7 +77,6 @@ def test_without(modules: Collection[str]) -> None:
 
 
 def main():
-    test_without(["json"])
     test_without(["yaml"])
     test_without([])
 

--- a/i18n/tests/translation_tests.py
+++ b/i18n/tests/translation_tests.py
@@ -169,7 +169,6 @@ class TestTranslationFormat(unittest.TestCase):
         config.set("on_missing_translation", return_default)
         self.assertEqual(t('inexistent_key', default='foo'), 'foo')
 
-    @unittest.skipUnless(config.json_available, "json library is not available")
     def test_skip_locale_root_data(self):
         config.set('filename_format', '{locale}.{format}')
         config.set('file_format', 'json')
@@ -179,7 +178,6 @@ class TestTranslationFormat(unittest.TestCase):
         self.assertEqual(t('foo'), 'Lorry')
         config.set('skip_locale_root_data', False)
 
-    @unittest.skipUnless(config.json_available, "json library is not available")
     def test_skip_locale_root_data_nested_json_dict__default_locale(self):
         config.set("file_format", "json")
         config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
@@ -189,7 +187,6 @@ class TestTranslationFormat(unittest.TestCase):
         resource_loader.init_json_loader()
         self.assertEqual(t('COMMON.START'), 'Start')
 
-    @unittest.skipUnless(config.json_available, "json library is not available")
     def test_skip_locale_root_data_nested_json_dict__other_locale(self):
         config.set("file_format", "json")
         config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])


### PR DESCRIPTION
The json module has been added as standard module from python2.4, and the i18nice project targets python3, so checking do json module avaliable is needn't.